### PR TITLE
Fixing the KaTeX formula rendering issue

### DIFF
--- a/src/pages/chat/components/ChatMessage/index.tsx
+++ b/src/pages/chat/components/ChatMessage/index.tsx
@@ -83,7 +83,7 @@ function ChatMessage({
   })
 
   mdi.use(mila, { attrs: { target: '_blank', rel: 'noopener' } })
-  mdi.use(mdKatex, { blockClass: 'katex-block', errorColor: ' #cc0000' })
+  mdi.use(mdKatex, { blockClass: 'katex-block', errorColor: ' #cc0000', output: 'mathml' })
 
   const text = useMemo(() => {
     const value = content || ''


### PR DESCRIPTION
公式渲染有问题似乎是因为有两种渲染方式，并且都output出来了，指定output为mathml即可。
![image](https://github.com/79E/ChatGpt-Web/assets/38845682/bf4ae22f-9f97-4e4e-91e6-8ac050eade08)

KateX文档：https://katex.org/docs/options.html

![image](https://github.com/79E/ChatGpt-Web/assets/38845682/96f799a2-6ed8-4255-9301-a47b90c8f13b)

#### 错误渲染
![S)AMJ`0F3`V3U3(~(2R$X0F](https://github.com/79E/ChatGpt-Web/assets/38845682/8288141f-f7aa-4b13-9ba2-7facac0042c0)

#### 正确渲染
![image](https://github.com/79E/ChatGpt-Web/assets/38845682/6dd451b7-115c-456e-be33-a09c177dc441)
